### PR TITLE
repo: Add RTCM3 sub through ethernet

### DIFF
--- a/drivers/synapse/eth_rx/src/main.c
+++ b/drivers/synapse/eth_rx/src/main.c
@@ -62,6 +62,9 @@ static void handle_frame(struct context *ctx)
 	} else if (frame->which_msg == synapse_pb_Frame_twist_tag) {
 		msg = &frame->msg.twist;
 		topic = &topic_cmd_vel_ethernet;
+	} else if (frame->which_msg == synapse_pb_Frame_rtcm3_tag) {
+		msg = &frame->msg.rtcm3;
+		topic = &topic_rtcm3;
 #ifdef CONFIG_SPINALI_DREAM_HIL
 	} else if (frame->which_msg == synapse_pb_Frame_battery_state_tag) {
 		msg = &frame->msg.battery_state;

--- a/drivers/synapse/topic/include/synapse_shell_print.h
+++ b/drivers/synapse/topic/include/synapse_shell_print.h
@@ -31,6 +31,7 @@ int snprint_pose(char *buf, size_t n, synapse_pb_Pose *m);
 int snprint_pwm(char *buf, size_t n, synapse_pb_Pwm *m);
 int snprint_quaternion(char *buf, size_t n, synapse_pb_Quaternion *m);
 int snprint_rates_sp(char *buf, size_t n, synapse_pb_Vector3 *m);
+int snprint_rtcm3(char *buf, size_t n, synapse_pb_Rtcm3 *m);
 int snprint_safety(char *buf, size_t n, synapse_pb_Safety *m);
 int snprint_status(char *buf, size_t n, synapse_pb_Status *m);
 int snprint_timestamp(char *buf, size_t n, synapse_pb_Timestamp *m);

--- a/drivers/synapse/topic/include/synapse_topic_list.h
+++ b/drivers/synapse/topic/include/synapse_topic_list.h
@@ -21,6 +21,7 @@
 #include <synapse_pb/odometry.pb.h>
 #include <synapse_pb/pwm.pb.h>
 #include <synapse_pb/quaternion.pb.h>
+#include <synapse_pb/rtcm3.pb.h>
 #include <synapse_pb/safety.pb.h>
 #include <synapse_pb/status.pb.h>
 #include <synapse_pb/twist.pb.h>
@@ -76,6 +77,7 @@ ZROS_TOPIC_DECLARE(topic_optical_flow_raw, synapse_pb_PixartPAA3905);
 ZROS_TOPIC_DECLARE(topic_orientation_sp, synapse_pb_Vector3);
 ZROS_TOPIC_DECLARE(topic_position_sp, synapse_pb_Vector3);
 ZROS_TOPIC_DECLARE(topic_pwm, synapse_pb_Pwm);
+ZROS_TOPIC_DECLARE(topic_rtcm3, synapse_pb_Rtcm3);
 ZROS_TOPIC_DECLARE(topic_safety, synapse_pb_Safety);
 ZROS_TOPIC_DECLARE(topic_status, synapse_pb_Status);
 ZROS_TOPIC_DECLARE(topic_velocity_sp, synapse_pb_Vector3);

--- a/drivers/synapse/topic/src/synapse_shell_print.c
+++ b/drivers/synapse/topic/src/synapse_shell_print.c
@@ -371,4 +371,9 @@ int snprint_wheel_odometry(char *buf, size_t n, synapse_pb_WheelOdometry *m)
 	return offset;
 }
 
+int snprint_rtcm3(char *buf, size_t n, synapse_pb_Rtcm3 *m)
+{
+	return snprintf_cat(buf, n, "len: %d", m->data.size);
+}
+
 // vi: ts=4 sw=4 et

--- a/drivers/synapse/topic/src/synapse_topic.c
+++ b/drivers/synapse/topic/src/synapse_topic.c
@@ -81,7 +81,8 @@ static context_t g_ctx = {.work_item = Z_WORK_INITIALIZER(topic_work_handler),
 		(orientation_sp, &topic_orientation_sp, "orientation_sp"),                         \
 		(optical_flow_raw, &topic_optical_flow_raw, "optical_flow_raw"),                   \
 		(position_sp, &topic_position_sp, "position_sp"), (pwm, &topic_pwm, "pwm"),        \
-		(safety, &topic_safety, "safety"), (status, &topic_status, "status"),              \
+		(rtcm3, &topic_rtcm3, "rtcm3"), (safety, &topic_safety, "safety"),                 \
+		(status, &topic_status, "status"),                                                 \
 		(velocity_sp, &topic_velocity_sp, "velocity_sp"),                                  \
 		(wheel_odometry, &topic_wheel_odometry, "wheel_odometry")
 

--- a/drivers/synapse/topic/src/synapse_topic_list.c
+++ b/drivers/synapse/topic/src/synapse_topic_list.c
@@ -210,6 +210,7 @@ ZROS_TOPIC_DEFINE(optical_flow_raw, synapse_pb_PixartPAA3905);
 ZROS_TOPIC_DEFINE(orientation_sp, synapse_pb_Quaternion);
 ZROS_TOPIC_DEFINE(position_sp, synapse_pb_Vector3);
 ZROS_TOPIC_DEFINE(pwm, synapse_pb_Pwm);
+ZROS_TOPIC_DEFINE(rtcm3, synapse_pb_Rtcm3);
 ZROS_TOPIC_DEFINE(safety, synapse_pb_Safety);
 ZROS_TOPIC_DEFINE(status, synapse_pb_Status);
 ZROS_TOPIC_DEFINE(velocity_sp, synapse_pb_Vector3);
@@ -247,6 +248,7 @@ static struct zros_topic *topic_list[] = {
 	&topic_optical_flow_raw,
 	&topic_position_sp,
 	&topic_pwm,
+	&topic_rtcm3,
 	&topic_safety,
 	&topic_status,
 	&topic_velocity_sp,

--- a/west.yml
+++ b/west.yml
@@ -42,7 +42,7 @@ manifest:
       path: modules/lib/cyecca
     - name: synapse_pb
       remote: cognipilot
-      revision: 44ebbd1ed65ace0e9f8efcaa502f464c92faa78b # main 12/10/25
+      revision: d14faa3fbce8ebe6412b252724ba3b47df1106c7 # main 12/16/25
       path: modules/lib/synapse_pb
     - name: hal_nxp
       remote: cognipilot


### PR DESCRIPTION
When enabled, RTCM3 messages coming through synapse will be forwarded
to the GNSS modem to apply data-corrections.

> [!NOTE]
> Requires:
> - GNSS app
> - MR-MCXN-T1 BSP for GNSS add-on.

> [!NOTE]
> Depends on:
> - #11 
> - https://github.com/CogniPilot/synapse_pb/pull/7
> - https://github.com/CogniPilot/zros_drivers/pull/27