### PR TITLE
synapse: adopt 0.9.0 schema and split the magnetometer to its own topic

### DIFF
--- a/drivers/synapse/topic/include/synapse_gnss_topic.h
+++ b/drivers/synapse/topic/include/synapse_gnss_topic.h
@@ -112,7 +112,7 @@ typedef struct synapse_topic_GnssFixData synapse_topic_GnssFix_t;
 #define SYNAPSE_TOPIC_GNSS_KEY "gnss"
 #define SYNAPSE_TOPIC_GNSS_CONTRACT                                                                \
 	"application/x-synapse-struct;type=synapse.topic.GnssFixData;"                             \
-	"schema=sha256-128:8add4005f50aaa07c9bbc502a2bd9b51"
+	"schema=sha256-128:d84f22749fb0af66d6869d93ca460465"
 
 /* Layout assertions, one per field, against the synapse_fbs schema. */
 BUILD_ASSERT(__BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__);

--- a/drivers/synapse/topic/include/synapse_imu_topic.h
+++ b/drivers/synapse/topic/include/synapse_imu_topic.h
@@ -60,30 +60,27 @@ enum synapse_types_TimeStatus {
 enum synapse_topic_InertialFieldFlags {
 	SYNAPSE_TOPIC_INERTIAL_FIELD_FLAG_ACCEL = 1U << 0, /* Accelerometer fields were updated. */
 	SYNAPSE_TOPIC_INERTIAL_FIELD_FLAG_GYRO = 1U << 1, /* Gyroscope fields were updated. */
-	SYNAPSE_TOPIC_INERTIAL_FIELD_FLAG_MAG = 1U << 2, /* Magnetometer fields were updated. */
-	SYNAPSE_TOPIC_INERTIAL_FIELD_FLAG_PRESSURE = 1U << 3, /* Static pressure was updated. */
-	SYNAPSE_TOPIC_INERTIAL_FIELD_FLAG_TEMPERATURE = 1U << 4, /* Temperature was updated. */
+	SYNAPSE_TOPIC_INERTIAL_FIELD_FLAG_TEMPERATURE = 1U << 2, /* Temperature was updated. */
 };
 
 /*
- * Raw inertial and environmental sample from an IMU-class sensor.
+ * Raw accelerometer, gyroscope, and temperature sample from an IMU sensor.
  *
  * Values are sensor-native measurements in the body FLU mounting frame after
- * driver axis alignment; no estimator products belong here. All vectors share
- * that frame, timestamp_ns shares one clock domain selected by time_status,
+ * driver axis alignment; no estimator products belong here. The magnetometer
+ * and barometer are separate sensors carried on their own topics (MagneticField
+ * and AirData). timestamp_ns shares one clock domain selected by time_status,
  * and sensors updating at different rates set the matching flags bits.
  */
 struct synapse_topic_InertialSampleData {
 	uint64_t timestamp_ns;
 	synapse_types_Vec3f_t accel_flu_m_s2;
 	synapse_types_Vec3f_t gyro_flu_rad_s;
-	synapse_types_Vec3f_t mag_flu_tesla;
-	float absolute_pressure_hpa;
 	float temperature_c;
 	uint8_t flags; /* enum synapse_topic_InertialFieldFlags */
 	uint8_t time_status; /* enum synapse_types_TimeStatus */
 	uint8_t id;
-	/* One trailing pad byte to 56; supplied by the struct's 8-byte alignment. */
+	/* One trailing pad byte to 40; supplied by the struct's 8-byte alignment. */
 };
 typedef struct synapse_topic_InertialSampleData synapse_topic_InertialSample_t;
 
@@ -95,23 +92,21 @@ typedef struct synapse_topic_InertialSampleData synapse_topic_InertialSample_t;
 #define SYNAPSE_TOPIC_IMU_KEY "imu"
 #define SYNAPSE_TOPIC_IMU_CONTRACT                                                                 \
 	"application/x-synapse-struct;type=synapse.topic.InertialSampleData;"                      \
-	"schema=sha256-128:8d1353f47696862d8971594acbf77a56"
+	"schema=sha256-128:d84f22749fb0af66d6869d93ca460465"
 
 /* Layout assertions, one per field, against the synapse_fbs schema. */
 BUILD_ASSERT(__BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__);
 
 BUILD_ASSERT(sizeof(synapse_types_Vec3f_t) == 12U);
 
-BUILD_ASSERT(sizeof(synapse_topic_InertialSample_t) == 56U);
+BUILD_ASSERT(sizeof(synapse_topic_InertialSample_t) == 40U);
 BUILD_ASSERT(offsetof(synapse_topic_InertialSample_t, timestamp_ns) == 0U);
 BUILD_ASSERT(offsetof(synapse_topic_InertialSample_t, accel_flu_m_s2) == 8U);
 BUILD_ASSERT(offsetof(synapse_topic_InertialSample_t, gyro_flu_rad_s) == 20U);
-BUILD_ASSERT(offsetof(synapse_topic_InertialSample_t, mag_flu_tesla) == 32U);
-BUILD_ASSERT(offsetof(synapse_topic_InertialSample_t, absolute_pressure_hpa) == 44U);
-BUILD_ASSERT(offsetof(synapse_topic_InertialSample_t, temperature_c) == 48U);
-BUILD_ASSERT(offsetof(synapse_topic_InertialSample_t, flags) == 52U);
-BUILD_ASSERT(offsetof(synapse_topic_InertialSample_t, time_status) == 53U);
-BUILD_ASSERT(offsetof(synapse_topic_InertialSample_t, id) == 54U);
+BUILD_ASSERT(offsetof(synapse_topic_InertialSample_t, temperature_c) == 32U);
+BUILD_ASSERT(offsetof(synapse_topic_InertialSample_t, flags) == 36U);
+BUILD_ASSERT(offsetof(synapse_topic_InertialSample_t, time_status) == 37U);
+BUILD_ASSERT(offsetof(synapse_topic_InertialSample_t, id) == 38U);
 
 #endif /* SYNAPSE_IMU_TOPIC_H */
 

--- a/drivers/synapse/topic/include/synapse_mag_topic.h
+++ b/drivers/synapse/topic/include/synapse_mag_topic.h
@@ -1,0 +1,105 @@
+/*
+ * Copyright CogniPilot Foundation 2025
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Magnetic-field topic payload and its Zenoh value contract, mirroring the
+ * synapse_fbs schema that vehicle-side consumers are built against.
+ *
+ * Source of truth for the layout and hash below is the synapse_fbs schema,
+ * fbs/sensors.fbs and fbs/types.fbs, exposed by topic-catalog entry 43
+ * (MagneticField, key "mag"). The struct declaration reproduces that
+ * fixed-layout little-endian struct field for field, so this file can be
+ * replaced by the generated struct header verbatim once the generated C
+ * catalog is available to this build.
+ *
+ * The payload is a fixed-layout little-endian struct published as raw bytes.
+ * A receiver decides whether to trust those bytes by string-comparing the
+ * value contract, which pins a schema hash and nothing about the actual field
+ * placement, so the offset assertions at the bottom of this file are part of
+ * the contract rather than a debugging aid: they are the only thing standing
+ * between a mis-ordered field and a silently misdecoded message.
+ */
+
+#ifndef SYNAPSE_MAG_TOPIC_H
+#define SYNAPSE_MAG_TOPIC_H
+
+#include <stddef.h>
+#include <stdint.h>
+
+#include <zephyr/sys/util.h>
+
+#ifndef SYNAPSE_TYPES_VEC3F
+#define SYNAPSE_TYPES_VEC3F
+struct synapse_types_Vec3f {
+	float x;
+	float y;
+	float z;
+};
+typedef struct synapse_types_Vec3f synapse_types_Vec3f_t;
+#endif /* SYNAPSE_TYPES_VEC3F */
+
+/*
+ * Discipline state of the clock behind the timestamp_ns field; mirrors
+ * synapse.types.TimeStatus. Stored in the one-byte time_status field below.
+ */
+#ifndef SYNAPSE_TYPES_TIME_STATUS_ENUM
+#define SYNAPSE_TYPES_TIME_STATUS_ENUM
+enum synapse_types_TimeStatus {
+	SYNAPSE_TYPES_TIME_STATUS_LOCAL_FREERUN = 0, /* Undisciplined monotonic boot clock. */
+	SYNAPSE_TYPES_TIME_STATUS_GPTP_SYNCED = 1, /* Disciplined to the gPTP grandmaster. */
+	SYNAPSE_TYPES_TIME_STATUS_GPTP_HOLDOVER = 2, /* Coasting after grandmaster loss. */
+};
+#endif /* SYNAPSE_TYPES_TIME_STATUS_ENUM */
+
+/*
+ * Bitmask stored in synapse_topic_MagneticFieldData.flags; mirrors
+ * synapse.topic.MagFieldFlags.
+ */
+enum synapse_topic_MagFieldFlags {
+	SYNAPSE_TOPIC_MAG_FIELD_FLAG_TEMPERATURE = 1U << 0, /* Sensor die temperature is valid. */
+};
+
+/*
+ * Raw magnetometer sample from a discrete magnetic-field sensor.
+ *
+ * Sensor-native field in the body FLU mounting frame after driver axis
+ * alignment, not declination corrected. timestamp_ns shares one clock domain
+ * selected by time_status.
+ */
+struct synapse_topic_MagneticFieldData {
+	uint64_t timestamp_ns;
+	synapse_types_Vec3f_t mag_flu_tesla;
+	float temperature_c;
+	uint8_t flags; /* enum synapse_topic_MagFieldFlags */
+	uint8_t time_status; /* enum synapse_types_TimeStatus */
+	uint8_t id;
+	/* Five trailing pad bytes to 32; supplied by the struct's 8-byte alignment. */
+};
+typedef struct synapse_topic_MagneticFieldData synapse_topic_MagneticField_t;
+
+/*
+ * Catalog key and value contract. The contract string is compared verbatim by
+ * the receiver, so the media type, wire type and schema hash must all match
+ * the catalog entry exactly.
+ */
+#define SYNAPSE_TOPIC_MAG_KEY "mag"
+#define SYNAPSE_TOPIC_MAG_CONTRACT                                                                  \
+	"application/x-synapse-struct;type=synapse.topic.MagneticFieldData;"                        \
+	"schema=sha256-128:d84f22749fb0af66d6869d93ca460465"
+
+/* Layout assertions, one per field, against the synapse_fbs schema. */
+BUILD_ASSERT(__BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__);
+
+BUILD_ASSERT(sizeof(synapse_types_Vec3f_t) == 12U);
+
+BUILD_ASSERT(sizeof(synapse_topic_MagneticField_t) == 32U);
+BUILD_ASSERT(offsetof(synapse_topic_MagneticField_t, timestamp_ns) == 0U);
+BUILD_ASSERT(offsetof(synapse_topic_MagneticField_t, mag_flu_tesla) == 8U);
+BUILD_ASSERT(offsetof(synapse_topic_MagneticField_t, temperature_c) == 20U);
+BUILD_ASSERT(offsetof(synapse_topic_MagneticField_t, flags) == 24U);
+BUILD_ASSERT(offsetof(synapse_topic_MagneticField_t, time_status) == 25U);
+BUILD_ASSERT(offsetof(synapse_topic_MagneticField_t, id) == 26U);
+
+#endif /* SYNAPSE_MAG_TOPIC_H */
+
+/* vi: ts=4 sw=4 et */

--- a/drivers/synapse/topic/include/synapse_topic_list.h
+++ b/drivers/synapse/topic/include/synapse_topic_list.h
@@ -29,6 +29,7 @@
 
 #include "synapse_gnss_topic.h"
 #include "synapse_imu_topic.h"
+#include "synapse_mag_topic.h"
 
 #if defined(CONFIG_SPINALI_VEHICLE_OPTICAL_FLOW) || defined(CONFIG_SPINALI_SYNAPSE_ZENOH)
 #include "synapse_optical_flow_topic.h"
@@ -68,6 +69,8 @@ ZROS_TOPIC_DECLARE(force_sp, synapse_pb_Vector3);
 ZROS_TOPIC_DECLARE(imu0, synapse_topic_InertialSample_t);
 ZROS_TOPIC_DECLARE(imu1, synapse_topic_InertialSample_t);
 ZROS_TOPIC_DECLARE(imu2, synapse_topic_InertialSample_t);
+ZROS_TOPIC_DECLARE(mag0, synapse_topic_MagneticField_t);
+ZROS_TOPIC_DECLARE(mag1, synapse_topic_MagneticField_t);
 ZROS_TOPIC_DECLARE(imu_q31_array, synapse_pb_ImuQ31Array);
 ZROS_TOPIC_DECLARE(input, synapse_pb_Input);
 ZROS_TOPIC_DECLARE(input_sbus, synapse_pb_Input);
@@ -96,6 +99,7 @@ ZROS_TOPIC_DECLARE(wheel_odometry, synapse_pb_WheelOdometry);
  * alias
  ********************************************************************/
 #define topic_imu topic_imu0
+#define topic_mag topic_mag0
 
 #endif // SYNAPSE_TOPIC_LIST_H_
 // vi: ts=4 sw=4 et

--- a/drivers/synapse/topic/src/synapse_topic_list.c
+++ b/drivers/synapse/topic/src/synapse_topic_list.c
@@ -195,6 +195,8 @@ ZROS_TOPIC_DEFINE(force_sp, synapse_pb_Vector3);
 ZROS_TOPIC_DEFINE(imu0, synapse_topic_InertialSample_t);
 ZROS_TOPIC_DEFINE(imu1, synapse_topic_InertialSample_t);
 ZROS_TOPIC_DEFINE(imu2, synapse_topic_InertialSample_t);
+ZROS_TOPIC_DEFINE(mag0, synapse_topic_MagneticField_t);
+ZROS_TOPIC_DEFINE(mag1, synapse_topic_MagneticField_t);
 ZROS_TOPIC_DEFINE(imu_q31_array, synapse_pb_ImuQ31Array);
 ZROS_TOPIC_DEFINE(input, synapse_pb_Input);
 ZROS_TOPIC_DEFINE(input_ethernet, synapse_pb_Input);
@@ -237,6 +239,8 @@ static struct zros_topic *topic_list[] = {
 	&topic_imu0,
 	&topic_imu1,
 	&topic_imu2,
+	&topic_mag0,
+	&topic_mag1,
 	&topic_imu_q31_array,
 	&topic_input,
 	&topic_input_ethernet,

--- a/drivers/synapse/zenoh/src/main.c
+++ b/drivers/synapse/zenoh/src/main.c
@@ -59,6 +59,7 @@ struct context {
 	synapse_topic_OpticalFlowVelocityData_t flow_vel;
 	synapse_topic_GnssFix_t gnss;
 	synapse_topic_InertialSample_t imu;
+	synapse_topic_MagneticField_t mag;
 #if SYNAPSE_ZENOH_RTCM3_INBOUND
 	/* inbound RTCM3 correction bytes, republished on topic_rtcm3 */
 	synapse_pb_Rtcm3 rtcm3;
@@ -82,6 +83,7 @@ static struct context g_ctx = {
 	.flow_vel = {},
 	.gnss = {},
 	.imu = {},
+	.mag = {},
 #if SYNAPSE_ZENOH_RTCM3_INBOUND
 	.rtcm3 = {},
 #endif
@@ -134,6 +136,13 @@ static const struct topic_binding topic_table[] = {
 		.size = sizeof(g_ctx.imu),
 		.key = SYNAPSE_TOPIC_IMU_KEY,
 		.contract = SYNAPSE_TOPIC_IMU_CONTRACT,
+	},
+	{
+		.topic = &topic_mag,
+		.buffer = &g_ctx.mag,
+		.size = sizeof(g_ctx.mag),
+		.key = SYNAPSE_TOPIC_MAG_KEY,
+		.contract = SYNAPSE_TOPIC_MAG_CONTRACT,
 	},
 };
 

--- a/west.yml
+++ b/west.yml
@@ -49,7 +49,7 @@ manifest:
       path: modules/lib/synapse_pb
     - name: zros_drivers
       remote: cognipilot
-      revision: e7260e2167f6347e06d56ed78d85fe69a2c70fda # fix/rtcm3-and-dual-mag (local, push before sharing)
+      revision: e3e122fab969acd447ad104ddd58972977497f3f # feature/synapse-fbs-0.9.0-mag (MagneticField mag driver)
       path: modules/lib/zros_drivers
     - name: zephyr_boards
       remote: cognipilot


### PR DESCRIPTION
Adopts the synapse_fbs 0.9.0 contract in the mcxn-t1 firmware and makes the magnetometer a first-class topic instead of a rider on the imu topic.

The firmware mirrors the sensor schema in hand-written headers pinned by a value-contract hash (it does not FetchContent the generated archive; `synapse_msgs_fbs` in the manifest is an unrelated logging mirror). This updates those mirrors to 0.9.0 and adds the magnetometer topic.

## Schema (mirror headers)
- InertialSample trimmed to 40 bytes: `mag_flu_tesla` and `absolute_pressure_hpa` removed (separate sensors in 0.9.0), `InertialFieldFlags` reduced to Accel/Gyro/Temperature.
- The shared per-file schema hash for the raw sensor topics is now `d84f22749fb0af66d6869d93ca460465` (imu, gnss, and the new mag). GnssFix layout was already 0.9.0-correct, so only its hash changed.

## MagneticField topic
- New `synapse_mag_topic.h`: `MagneticFieldData` (catalog id 43, key "mag", 32 bytes), `MagFieldFlags`, the contract, and offset asserts.
- `mag0`/`mag1` broker topics + a `topic_mag` alias, and a Zenoh publisher row so "mag" goes out on its own key.

## Coupling
Requires the zros_drivers change (CogniPilot/zros_drivers#34) whose streaming mag driver now publishes MagneticField on `topic_mag` instead of writing a removed field into InertialSample on `topic_imu`. The manifest pin for zros_drivers is advanced to that commit here; re-point it to the merge commit after #34 lands.

## Validation
Built clean for `mr_mcxn_t1/mcxn947/cpu0`: flex_io, optical_flow, and rtk_gnss (Zephyr SDK 1.0.1). Full CI green also depends on the other local-dev module pins in `west.yml` (zros, zephyr_boards, synapse_msgs_fbs, ...) being pushed and consistent, which is separate from this change.
